### PR TITLE
Remove legacy asyncio requirement

### DIFF
--- a/pymiele/const.py
+++ b/pymiele/const.py
@@ -1,4 +1,4 @@
-VERSION = "0.1.6"
+VERSION = "0.1.7"
 
 MIELE_API = "https://api.mcs3.miele.com/v1"
 OAUTH2_AUTHORIZE = "https://api.mcs3.miele.com/thirdparty/login"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.6
+current_version = 0.1.7
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,5 @@ setuptools.setup(
         "Development Status :: 5 - Production/Stable",
     ],
     python_requires='>=3.9',
-    install_requires=["aiohttp" ,"asyncio", "async_timeout"],
+    install_requires=["aiohttp", "async_timeout",],
 )


### PR DESCRIPTION
The requirement of asyncio in setup.py caused version collision in HA. Resolves #5 